### PR TITLE
Fixed meta tags for responsive UI behaviour

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
-    <%= tag :meta, property: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: image_url('govuk-opengraph-image.png') %>
-    <%= tag :meta, property: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
### Context

The main template doesn't currently resize appropriately on mobile devices

### Changes proposed in this pull request

Use meta tags with `name:` instead of `property:`

### Guidance to review

Works for me - needs testing against an emulated mobile browser (or real one) since just resizing a browser window doesn't trigger the problem.