### PR TITLE
Update govuk frontend to version 3

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-    <header class="govuk-header " role="banner" data-module="header">
+    <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <%= link_to "/", class: "govuk-header__link govuk-header__link--homepage" do %>
@@ -42,7 +42,7 @@
         </div>
         <div class="govuk-header__content">
           <%= link_to "GOV.UK Rails Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <button type="button" role="govuk-button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item govuk-header__navigation-item--active">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
         </div>
         <div class="govuk-header__content">
           <%= link_to "GOV.UK Rails Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <button type="button" role="govuk-button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item govuk-header__navigation-item--active">

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -1,1 +1,1 @@
-@import "../../../node_modules/govuk-frontend/all";
+@import "../../../node_modules/govuk-frontend/govuk/all";

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,4 +4,4 @@
 Rails.application.config.assets.version = '1.0'
 
 # Add GOVUK frontend asset path
-Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "assets")
+Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "govuk", "assets")

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -5,8 +5,8 @@ const environment = require('./environment')
 
 environment.config.plugins = (environment.config.plugins || []).concat([
   new CopyWebpackPlugin([
-    { from: 'node_modules/govuk-frontend/assets/fonts/**/*', to: '../assets/fonts/', flatten: true },
-    { from: 'node_modules/govuk-frontend/assets/images/**/*', to: '../assets/images/', flatten: true }
+    { from: 'node_modules/govuk-frontend/govuk/assets/fonts/**/*', to: '../assets/fonts/', flatten: true },
+    { from: 'node_modules/govuk-frontend/govuk/assets/images/**/*', to: '../assets/images/', flatten: true }
   ])
 ])
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
     "copy-webpack-plugin": "^5.0.4",
-    "govuk-frontend": "^2.13.0",
+    "govuk-frontend": "^3.0.0",
     "rails-ujs": "^5.2.3",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,10 +3103,10 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-govuk-frontend@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.13.0.tgz#0273f7c92070abd6450c73a006ebb3ddc793463a"
-  integrity sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw==
+govuk-frontend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.0.0.tgz#27e4751592c0587ec925c637dcd1a2582429afe4"
+  integrity sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.1.15"


### PR DESCRIPTION
### Context

Version 3 of the GOV.UK Frontend was just released, this change brings the boilerplate up to date

### Changes proposed in this pull request

Increase the `govuk-frontend` version number to `^3.0.0` in `package.json` and modify the scss import path to include `govuk`, as specified in [the breaking changes section of the changelog](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

### Guidance to review

A sanity check and making sure things still work. With these changes in place I was able to run the app with the GOV.UK theme visible and functional and add a `textarea` with character and word counts - I think this is sufficient to indicate that everything's functional?