### PR TITLE
Add manifest.yml and instructions to deploy to Cloud Foundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.bundle
+.byebug_history
+.env
+.nvmrc
+.rvmrc
+
+log
+tmp
+storage

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /public/packs
 /public/packs-test
 /node_modules
+/vendor/cache
 yarn-debug.log*
 .yarn-integrity
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 - Rails 6.0 with Webpacker
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
-- [GOV.UK Lint](https://github.com/alphagov/govuk-lint)
 - RSpec
 - Dotenv (managing environment variables)
 - Travis with Heroku deployment
@@ -47,3 +46,23 @@ or
 
 bundle exec scss-lint app/webpacker/styles
 ```
+
+## Deploying on GOV.UK PaaS
+
+### Prerequisites
+
+- Your department, agency or team has a GOV.UK PaaS account
+- You have a personal account granted by your organisation manager
+- You have downloaded and installed the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli#downloads) for your platform
+
+### Deploy
+
+1. Run `cf login -a api.london.cloud.service.gov.uk -u USERNAME`, `USERNAME` is your personal GOV.UK PaaS account email address
+2. Run `bundle package --all` to vendor ruby dependencies
+3. Run `yarn` to vendor node dependencies
+4. Run `bundle exec rails webpacker:compile` to compile assets
+5. Run `cf push` to push the app to Cloud Foundry Application Runtime
+
+Check the file `manifest.yml` for customisation of name (you may need to change it as there could be a conflict on that name), buildpacks and eventual services (PostgreSQL needs to be [set up](https://docs.cloud.service.gov.uk/deploying_services/postgresql/)).
+
+The app should be available at https://govuk-rails-boilerplate.london.cloudapps.digital

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: govuk-rails-boilerplate
+  buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git
+    - https://github.com/cloudfoundry/nodejs-buildpack


### PR DESCRIPTION
### Context
This PR adds the instructions and required `manifest.yml` and `.cfignore` files to easily deploy this app on GOV.UK PaaS
