### PR TITLE
Remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/DFE-Digital/govuk-rails-boilerplate.svg?branch=master)](https://travis-ci.com/DFE-Digital/govuk-rails-boilerplate) [![Greenkeeper badge](https://badges.greenkeeper.io/DFE-Digital/govuk-rails-boilerplate.svg)](https://greenkeeper.io/)
+[![Build Status](https://travis-ci.org/DFE-Digital/govuk-rails-boilerplate.svg?branch=master)](https://travis-ci.com/DFE-Digital/govuk-rails-boilerplate)
 
 # GOV.UK Rails Boilerplate
 


### PR DESCRIPTION
### Context
Dependabot manages Javascript and Ruby dependencies

### Changes proposed in this pull request
Remove Greenkeeper badge in the Readme

### Guidance to review
🚢 
