### PR TITLE
Fixes rubocop errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,4 @@
-class ErrorsController < ActionController::Base
+class ErrorsController < ApplicationController
   layout "application"
 
   def not_found

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp", "caching-dev.txt").exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,11 +1,11 @@
 desc "Lint ruby code"
 namespace :lint do
-  task :ruby do
+  task ruby: :environment do
     puts "Linting ruby..."
     system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
   end
 
-  task :scss do
+  task scss: :environment do
     puts "Linting scss..."
     system "bundle exec scss-lint app/webpacker/styles"
   end


### PR DESCRIPTION
### Context
I noticed Travis CI was [failing on the master branch](https://travis-ci.org/DFE-Digital/govuk-rails-boilerplate/builds/631005794). It turned out to be a few linting issues.

C: [Corrected] Rails/ApplicationController: Controllers should subclass
   ApplicationController. errors_controller.rb
C: Rails/RakeEnvironment: Set :environment task as a dependency to all rake task.
C: Rails/FilePath: Please use Rails.root.join('path/to') instead.

### Changes proposed in this pull request
A relatively small change that addresses the linting errors rubocop raised.

### Guidance to review

