### PR TITLE
Replace chrome/selenium driver gem with webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ group :development, :test do
 
   # Testing framework
   gem "rspec-rails", "~> 4.0.0.beta3"
+  # Adds support for Capybara system testing and selenium driver
+  gem "capybara", "~> 3.30"
 
   gem "dotenv-rails"
 end
@@ -55,12 +57,7 @@ group :development do
 end
 
 group :test do
-  # Adds support for Capybara system testing and selenium driver
-  gem "capybara", ">= 2.15"
-
-  gem "selenium-webdriver"
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem "chromedriver-helper"
+  gem "webdrivers", "~> 3.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,8 +58,6 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     ast (2.4.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
@@ -77,9 +75,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
@@ -95,7 +90,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.4)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -200,7 +194,7 @@ GEM
     rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    rubyzip (2.0.0)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -234,6 +228,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -252,8 +250,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   canonical-rails
-  capybara (>= 2.15)
-  chromedriver-helper
+  capybara (~> 3.30)
   dotenv-rails
   foreman
   listen (>= 3.0.5, < 3.3)
@@ -264,11 +261,11 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0.beta3)
   rubocop-govuk
   scss_lint-govuk
-  selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers (~> 3.0)
   webpacker
 
 RUBY VERSION


### PR DESCRIPTION
### Context
When running tests the following warning was being logged:

```
WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is
deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
/Users/aliuk2012/.rbenv/versions/2.6.5/bin/ruby
-I/Users/aliuk2012/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.0/lib:
/Users/aliuk2012/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-support-3.9.0/lib
/Users/aliuk2012/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rspec-core-3.9.0/exe/rspec -
-pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
2019-12-31 13:20:22 WARN Selenium [DEPRECATION]
Selenium::WebDriver::Chrome#driver_path= is deprecated. Use
Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

### Changes proposed in this pull request

The reason is that chrome-drivers has been **deprecated since 2019-03-31**.
It is recommended to use `webdrivers` gem (Selenium tests more easily
with automatic installation and updates for all supported webdrivers)

Other references:
https://github.com/titusfortner/webdrivers
https://stackoverflow.com/questions/55970418/capyabra-selenium-chrome-driver-settings


### Guidance to review
Travis CI should not be logging any of the above deprecation warnings.
