### PR TITLE
Add GOV.UK date formats for use in Rails' helpers

### DIFF
--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,4 @@
+# https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+Date::DATE_FORMATS[:govuk]        = "%-d %B %Y" # 2 January 1998
+Date::DATE_FORMATS[:govuk_short]  = "%-d %b %Y" # 2 Jan 1998
+Date::DATE_FORMATS[:govuk_approx] = "%B %Y"     # January 1998


### PR DESCRIPTION
Rails allows custom date formats to be configured and used throughout an application [via `Date::DATE_FORMATS`](https://api.rubyonrails.org/classes/Date.html). There is one recommended way to display dates in the Design System - (numeric day, full month name, numeric year with spaces between, eg '4 January 2017') - and the only further tweaks to this pattern are when:
* [the date is approximate and the day is removed](https://design-system.service.gov.uk/patterns/dates/) (eg 'January 2017')
* [space is an issue and the month is abbreviated](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates) (eg '4 Jan 2017')

This idea was proposed in the govuk-components [tracker](https://github.com/DFE-Digital/govuk-components/issues/18), but the boilerplate is a better home for it. It should be useful for most (probably all) projects.

These use cases are covered by the formats `:govuk`, `:govuk_short` and
`:govuk_approx`.

## Example use

```
irb(main):002:0> Date.today.to_formatted_s(:govuk)
=> "8 June 2020"
irb(main):003:0> Date.today.to_formatted_s(:govuk_short)
=> "8 Jun 2020"
irb(main):004:0> Date.today.to_formatted_s(:govuk_approx)
=> "June 2020"
irb(main):005:0>
```