### PR TITLE
Fix the header toggle to work with govuk-frontend >= 3.0.0

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
         </div>
         <div class="govuk-header__content">
           <%= link_to "GOV.UK Rails Boilerplate", "/", class: "govuk-header__link govuk-header__link--service-name" %>
-          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <button type="button" role="button" data-module="govuk-button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item govuk-header__navigation-item--active">


### PR DESCRIPTION
### Context

The nav toggle (hamburger on mobile) doesn't work.

### Changes proposed in this pull request

- Update the CSS class that was [renamed in `govuk-frontend` in v3.0.0](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md#update-css-class-names)
