### PR TITLE
Update Rubocop config and fix errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,13 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - 'db/schema.rb'
+    - 'node_modules/**/*'
+    - 'config/application.rb'
+    - 'config/puma.rb'
+    - 'config/environments/*'
+    - 'vendor/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,5 +10,4 @@ AllCops:
     - 'node_modules/**/*'
     - 'config/application.rb'
     - 'config/puma.rb'
-    - 'config/environments/*'
     - 'vendor/**/*'

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task lint_ruby: ['lint:ruby']
-task lint_scss: ['lint:scss']
+task lint_ruby: ["lint:ruby"]
+task lint_scss: ["lint:scss"]
 task default: %i[spec lint_ruby lint_scss]

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task lint_ruby: ["lint:ruby"]
-task lint_scss: ["lint:scss"]
-task default: %i[spec lint_ruby lint_scss]
+task default: ["spec", "lint:ruby", "lint:scss"]

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -8,7 +8,7 @@ CanonicalRails.setup do |config|
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
   config.host = "www.education.gov.uk"
-  config.port# = '3000'
+  config.port # = '3000'
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
@@ -16,12 +16,12 @@ CanonicalRails.setup do |config|
   #
   # Acts as a whitelist for routes to have trailing slashes
 
-  config.collection_actions# = [:index]
+  config.collection_actions # = [:index]
 
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
   # Unless whitelisted, these parameters will be omitted
 
-  config.whitelisted_parameters# = []
+  config.whitelisted_parameters # = []
 
   # Output a matching OpenGraph URL meta tag (og:url) with the canonical URL, as recommended by Facebook et al
   config.opengraph_url = true

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -3,7 +3,7 @@ namespace :lint do
   desc "Lint Ruby with Rubocop"
   task ruby: :environment do
     puts "Linting ruby..."
-    system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
+    system "bundle exec rubocop --format clang -a"
   end
 
   desc "Lint SCSS with scss_lint"

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,10 +1,12 @@
 desc "Lint ruby code"
 namespace :lint do
+  desc "Lint Ruby with Rubocop"
   task ruby: :environment do
     puts "Linting ruby..."
     system "bundle exec rubocop app config db lib spec Gemfile --format clang -a"
   end
 
+  desc "Lint SCSS with scss_lint"
   task scss: :environment do
     puts "Linting scss..."
     system "bundle exec scss-lint app/webpacker/styles"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
### Context

On `master`, Rubocop is throwing warnings.

### Changes proposed in this pull request

- Improve how Rubocop is configured so it ignores stuff that it doesn't really belong to the app code.
- Fix the remaining warnings.

### Guidance to review

Best reviewed commit by commit.